### PR TITLE
Add React Kanban boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.dist
+.vscode
+.idea
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# atomic-productivity
+# Atomic Productivity
+
+A minimal Kanban-style productivity board built with React and Vite. Use this boilerplate to jump-start a to-do manager where tasks flow across backlog, to-do, in-progress, review, and done columns.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The development server runs at `http://localhost:3000` and automatically reloads when you edit files.
+
+## Project structure
+
+```text
+src/
+  App.jsx                # Page composition and layout
+  main.jsx               # React entry point
+  components/            # Presentational UI building blocks
+  hooks/useKanbanBoard.js# Encapsulated state and persistence logic
+  styles/global.css      # Shared styling tokens and layout rules
+```
+
+## Features
+
+- Preconfigured Vite + React tooling for fast development and production builds
+- Opinionated Kanban workflow with five standard stages
+- Local storage persistence for tasks between sessions
+- Accessible keyboard-friendly interactions for moving tasks across columns
+- Responsive layout that gracefully adapts to mobile screens
+
+## Next steps
+
+This boilerplate intentionally focuses on essentials. Potential enhancements include:
+
+- Integrating drag-and-drop interactions (e.g., via `@dnd-kit`)
+- Syncing board state with an API or collaboration backend
+- Adding filters, swimlanes, or WIP limits for advanced workflows
+- Introducing authentication and per-user boards

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Atomic Productivity - Kanban</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "atomic-productivity",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "prop-types": "^15.8.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.3",
+    "eslint": "^8.45.0",
+    "eslint-config-standard-with-typescript": "^43.0.0",
+    "eslint-plugin-import": "^2.28.0",
+    "eslint-plugin-n": "^16.0.1",
+    "eslint-plugin-promise": "^6.1.1",
+    "typescript": "^5.1.6",
+    "vite": "^4.4.9"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,45 @@
+import KanbanColumn from './components/KanbanColumn.jsx';
+import NewTaskForm from './components/NewTaskForm.jsx';
+import { useKanbanBoard } from './hooks/useKanbanBoard.js';
+
+const App = () => {
+  const {
+    columns,
+    tasksByColumn,
+    addTask,
+    moveTaskBackward,
+    moveTaskForward,
+    deleteTask
+  } = useKanbanBoard();
+
+  return (
+    <div className="app-shell">
+      <header className="app-shell__header">
+        <h1>Atomic Productivity</h1>
+        <p>Ship work with a focused Kanban workflow.</p>
+      </header>
+
+      <section className="app-shell__new-task">
+        <h2>Create a task</h2>
+        <NewTaskForm onSubmit={addTask} />
+      </section>
+
+      <main className="kanban-board" aria-label="Kanban board">
+        {columns.map((column, index) => (
+          <KanbanColumn
+            key={column.id}
+            column={column}
+            tasks={tasksByColumn[column.id] ?? []}
+            position={index}
+            totalColumns={columns.length}
+            onMoveBackward={moveTaskBackward}
+            onMoveForward={moveTaskForward}
+            onDelete={deleteTask}
+          />
+        ))}
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/KanbanColumn.jsx
+++ b/src/components/KanbanColumn.jsx
@@ -1,0 +1,60 @@
+import PropTypes from 'prop-types';
+import KanbanTask from './KanbanTask.jsx';
+
+const KanbanColumn = ({ column, tasks, position, totalColumns, onMoveBackward, onMoveForward, onDelete }) => {
+  const isFirstColumn = position === 0;
+  const isLastColumn = position === totalColumns - 1;
+
+  return (
+    <section className="kanban-column">
+      <header className="kanban-column__header">
+        <h2>{column.title}</h2>
+        <p>{column.description}</p>
+      </header>
+      <div className="kanban-column__body">
+        {tasks.length === 0 ? (
+          <p className="kanban-column__empty">No tasks yet</p>
+        ) : (
+          tasks.map((task) => (
+            <KanbanTask
+              key={task.id}
+              task={task}
+              onMoveBackward={onMoveBackward}
+              onMoveForward={onMoveForward}
+              onDelete={onDelete}
+              isFirstColumn={isFirstColumn}
+              isLastColumn={isLastColumn}
+            />
+          ))
+        )}
+      </div>
+    </section>
+  );
+};
+
+KanbanColumn.propTypes = {
+  column: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string
+  }).isRequired,
+  tasks: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      description: PropTypes.string,
+      status: PropTypes.string.isRequired
+    })
+  ),
+  position: PropTypes.number.isRequired,
+  totalColumns: PropTypes.number.isRequired,
+  onMoveBackward: PropTypes.func.isRequired,
+  onMoveForward: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired
+};
+
+KanbanColumn.defaultProps = {
+  tasks: []
+};
+
+export default KanbanColumn;

--- a/src/components/KanbanTask.jsx
+++ b/src/components/KanbanTask.jsx
@@ -1,0 +1,46 @@
+import PropTypes from 'prop-types';
+
+const KanbanTask = ({ task, onMoveBackward, onMoveForward, onDelete, isFirstColumn, isLastColumn }) => {
+  return (
+    <article className="task-card">
+      <header className="task-card__header">
+        <h3>{task.title}</h3>
+      </header>
+      {task.description && <p className="task-card__description">{task.description}</p>}
+      <footer className="task-card__footer">
+        <div className="task-card__actions">
+          <button type="button" onClick={() => onMoveBackward(task.id)} disabled={isFirstColumn}>
+            ←
+          </button>
+          <button type="button" onClick={() => onMoveForward(task.id)} disabled={isLastColumn}>
+            →
+          </button>
+        </div>
+        <button type="button" className="task-card__delete" onClick={() => onDelete(task.id)}>
+          Remove
+        </button>
+      </footer>
+    </article>
+  );
+};
+
+KanbanTask.propTypes = {
+  task: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    status: PropTypes.string.isRequired
+  }).isRequired,
+  onMoveBackward: PropTypes.func.isRequired,
+  onMoveForward: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  isFirstColumn: PropTypes.bool,
+  isLastColumn: PropTypes.bool
+};
+
+KanbanTask.defaultProps = {
+  isFirstColumn: false,
+  isLastColumn: false
+};
+
+export default KanbanTask;

--- a/src/components/NewTaskForm.jsx
+++ b/src/components/NewTaskForm.jsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+
+const initialState = {
+  title: '',
+  description: ''
+};
+
+const NewTaskForm = ({ onSubmit }) => {
+  const [values, setValues] = useState(initialState);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setValues((current) => ({ ...current, [name]: value }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (!values.title.trim()) {
+      return;
+    }
+    onSubmit(values);
+    setValues(initialState);
+  };
+
+  return (
+    <form className="new-task-form" onSubmit={handleSubmit}>
+      <div className="new-task-form__field">
+        <label htmlFor="title">Title</label>
+        <input
+          id="title"
+          name="title"
+          type="text"
+          value={values.title}
+          placeholder="Add a new task"
+          onChange={handleChange}
+          required
+        />
+      </div>
+      <div className="new-task-form__field">
+        <label htmlFor="description">Description</label>
+        <textarea
+          id="description"
+          name="description"
+          value={values.description}
+          placeholder="Optional context for the task"
+          onChange={handleChange}
+          rows={3}
+        />
+      </div>
+      <div className="new-task-form__actions">
+        <button type="submit">Add to backlog</button>
+      </div>
+    </form>
+  );
+};
+
+NewTaskForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired
+};
+
+export default NewTaskForm;

--- a/src/hooks/useKanbanBoard.js
+++ b/src/hooks/useKanbanBoard.js
@@ -1,0 +1,155 @@
+import { useCallback, useMemo, useState } from 'react';
+
+const STORAGE_KEY = 'atomic-productivity::kanban';
+
+const createId = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2, 10);
+
+const defaultColumns = [
+  { id: 'backlog', title: 'Backlog', description: 'Ideas and unsorted work' },
+  { id: 'todo', title: 'To Do', description: 'Committed work ready to be started' },
+  { id: 'in-progress', title: 'In Progress', description: 'Work that is currently underway' },
+  { id: 'review', title: 'Review', description: 'Work awaiting validation or QA' },
+  { id: 'done', title: 'Done', description: 'Completed and accepted work' }
+];
+
+const defaultTasks = [
+  {
+    id: createId(),
+    title: 'Draft user stories',
+    description: 'Outline the core user journeys for the MVP.',
+    status: 'backlog'
+  },
+  {
+    id: createId(),
+    title: 'Set up CI pipeline',
+    description: 'Configure automated tests and deployments.',
+    status: 'in-progress'
+  },
+  {
+    id: createId(),
+    title: 'UX review',
+    description: 'Review wireframes with the design team.',
+    status: 'review'
+  }
+];
+
+const loadState = () => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return defaultTasks;
+  }
+
+  try {
+    const serialized = window.localStorage.getItem(STORAGE_KEY);
+    if (!serialized) {
+      return defaultTasks;
+    }
+    const parsed = JSON.parse(serialized);
+    if (!Array.isArray(parsed)) {
+      return defaultTasks;
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to read stored kanban state', error);
+    return defaultTasks;
+  }
+};
+
+const persistState = (tasks) => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
+  } catch (error) {
+    console.warn('Failed to persist kanban state', error);
+  }
+};
+
+export const useKanbanBoard = () => {
+  const [tasks, setTasks] = useState(() => loadState());
+
+  const updateTasks = useCallback((updater) => {
+    setTasks((current) => {
+      const next = typeof updater === 'function' ? updater(current) : updater;
+      persistState(next);
+      return next;
+    });
+  }, []);
+
+  const addTask = useCallback((task) => {
+    updateTasks((current) => [
+      {
+        id: createId(),
+        status: 'todo',
+        ...task
+      },
+      ...current
+    ]);
+  }, [updateTasks]);
+
+  const updateTaskStatus = useCallback((taskId, status) => {
+    updateTasks((current) =>
+      current.map((task) =>
+        task.id === taskId
+          ? { ...task, status }
+          : task
+      )
+    );
+  }, [updateTasks]);
+
+  const deleteTask = useCallback((taskId) => {
+    updateTasks((current) => current.filter((task) => task.id !== taskId));
+  }, [updateTasks]);
+
+  const tasksByColumn = useMemo(() => {
+    return defaultColumns.reduce((accumulator, column) => {
+      return {
+        ...accumulator,
+        [column.id]: tasks.filter((task) => task.status === column.id)
+      };
+    }, {});
+  }, [tasks]);
+
+  const moveTaskForward = useCallback((taskId) => {
+    updateTasks((current) => {
+      const statuses = defaultColumns.map((column) => column.id);
+      return current.map((task) => {
+        if (task.id !== taskId) {
+          return task;
+        }
+        const index = statuses.indexOf(task.status);
+        const nextStatus = statuses[Math.min(index + 1, statuses.length - 1)];
+        return { ...task, status: nextStatus };
+      });
+    });
+  }, [updateTasks]);
+
+  const moveTaskBackward = useCallback((taskId) => {
+    updateTasks((current) => {
+      const statuses = defaultColumns.map((column) => column.id);
+      return current.map((task) => {
+        if (task.id !== taskId) {
+          return task;
+        }
+        const index = statuses.indexOf(task.status);
+        const nextStatus = statuses[Math.max(index - 1, 0)];
+        return { ...task, status: nextStatus };
+      });
+    });
+  }, [updateTasks]);
+
+  return {
+    columns: defaultColumns,
+    tasks,
+    tasksByColumn,
+    addTask,
+    updateTaskStatus,
+    moveTaskForward,
+    moveTaskBackward,
+    deleteTask
+  };
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,231 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: #0f172a;
+  color: #e2e8f0;
+  --surface: rgba(15, 23, 42, 0.8);
+  --surface-alt: rgba(30, 41, 59, 0.8);
+  --border: rgba(148, 163, 184, 0.2);
+  --accent: #38bdf8;
+  --accent-soft: rgba(56, 189, 248, 0.15);
+  --danger: #f87171;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.1), transparent),
+    radial-gradient(circle at bottom, rgba(99, 102, 241, 0.15), transparent),
+    #020617;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.app-shell {
+  padding: 2rem clamp(1rem, 5vw, 3rem) 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.app-shell__header {
+  text-align: center;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.app-shell__header h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 700;
+}
+
+.app-shell__new-task {
+  background: var(--surface);
+  padding: 1.5rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 1rem 3rem rgba(15, 23, 42, 0.35);
+  display: grid;
+  gap: 1rem;
+}
+
+.new-task-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.new-task-form__field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.new-task-form__field label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.new-task-form__field input,
+.new-task-form__field textarea {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  background: var(--surface-alt);
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.new-task-form__field input:focus,
+.new-task-form__field textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.new-task-form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.new-task-form__actions button {
+  padding: 0.65rem 1.5rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #0f172a;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.kanban-board {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.kanban-column {
+  background: var(--surface);
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 0.5rem 2rem rgba(15, 23, 42, 0.3);
+  display: flex;
+  flex-direction: column;
+  min-height: 280px;
+}
+
+.kanban-column__header {
+  padding: 1.25rem 1.5rem 1rem;
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.kanban-column__header h2 {
+  font-size: 1.1rem;
+}
+
+.kanban-column__header p {
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.kanban-column__body {
+  padding: 1.25rem 1.5rem 1.5rem;
+  display: grid;
+  gap: 1rem;
+  flex: 1;
+}
+
+.kanban-column__empty {
+  font-size: 0.9rem;
+  color: #94a3b8;
+  text-align: center;
+  padding: 1rem;
+  border: 1px dashed var(--border);
+  border-radius: 0.75rem;
+}
+
+.task-card {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.05);
+}
+
+.task-card__header h3 {
+  font-size: 1rem;
+}
+
+.task-card__description {
+  font-size: 0.9rem;
+  color: #cbd5f5;
+}
+
+.task-card__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.task-card__actions {
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.task-card__actions button {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+}
+
+.task-card__actions button:hover:not(:disabled) {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.task-card__delete {
+  background: transparent;
+  border: none;
+  color: var(--danger);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .kanban-board {
+    grid-template-columns: 1fr;
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+    open: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite-powered React application for managing tasks in a Kanban workflow
- implement board state management with reusable column/task components and local storage persistence
- add styling and documentation to describe project structure and usage

## Testing
- not run (npm install blocked by 403 from registry)


------
https://chatgpt.com/codex/tasks/task_e_68e4fa33b9c0832784ed31ece9b54575